### PR TITLE
Make author URLs optional in Pages CMS

### DIFF
--- a/.pages.yml
+++ b/.pages.yml
@@ -124,22 +124,18 @@ content:
           - name: url
             label: URL
             type: string
-            required: false
-            pattern: ^(https?:\/\/)?(www\.)?[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}(\/[^\s]*)?$
+            pattern: (^(https?:\/\/)?(www\.)?[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}(\/[^\s]*)?$)?
           - name: mastodon_url
             label: Mastodon URL
             type: string
-            required: false
-            pattern: ^(https?:\/\/)?(www\.)?[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}(\/[^\s]*)?$
+            pattern: (^(https?:\/\/)?(www\.)?[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}(\/[^\s]*)?$)?
           - name: threads_url
             label: Threads URL
             type: string
-            required: false
             default: https://www.threads.net/
-            pattern: ^(https?:\/\/)?www.threads.net\/@[^\s]+$
+            pattern: (^(https?:\/\/)?www.threads.net\/@[^\s]+$)?
           - name: github_url
             label: GitHub URL
             type: string
-            required: false
             default: https://github.com/
-            pattern: ^(https?:\/\/)?github.com(\/[^\s]*)?$
+            pattern: (^(https?:\/\/)?github.com(\/[^\s]*)?$)?

--- a/.pages.yml
+++ b/.pages.yml
@@ -124,18 +124,22 @@ content:
           - name: url
             label: URL
             type: string
+            required: false
             pattern: ^(https?:\/\/)?(www\.)?[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}(\/[^\s]*)?$
           - name: mastodon_url
             label: Mastodon URL
             type: string
+            required: false
             pattern: ^(https?:\/\/)?(www\.)?[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}(\/[^\s]*)?$
           - name: threads_url
             label: Threads URL
             type: string
+            required: false
             default: https://www.threads.net/
             pattern: ^(https?:\/\/)?www.threads.net\/@[^\s]+$
           - name: github_url
             label: GitHub URL
             type: string
+            required: false
             default: https://github.com/
             pattern: ^(https?:\/\/)?github.com(\/[^\s]*)?$

--- a/_data/site.json
+++ b/_data/site.json
@@ -1,14 +1,12 @@
 {
-	"title": "seanlunsford.com",
-	"url": "https://seanlunsford.com",
-	"language": "en",
-	"github_url": "https://github.com/slunsford/seanlunsford.com",
-	"author": {
-		"name": "Sean Lunsford",
-		"email": "sean@seanlunsford.com",
-		"url": "https://seanlunsford.com",
-		"mastodon_url": "https://data-folks.masto.host/@sean",
-		"threads_url": "https://www.threads.net/@splunsford",
-		"github_url": "https://github.com/slunsford"
-	}
+  "title": "seanlunsford.com",
+  "url": "https://seanlunsford.com",
+  "github_url": "https://github.com/slunsford/seanlunsford.com",
+  "author": {
+    "name": "Sean Lunsford",
+    "email": "sean@seanlunsford.com",
+    "url": "https://seanlunsford.com",
+    "mastodon_url": "https://data-folks.masto.host/@sean",
+    "github_url": "https://github.com/slunsford"
+  }
 }


### PR DESCRIPTION
Updated patterns to allow removing of URLs (Threads, specifically)