### PR TITLE
Fix abbr filter to escape HTML entities before processing

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -91,7 +91,9 @@ module.exports = function(eleventyConfig) {
 
     eleventyConfig.addFilter("abbr", function(text) {
         if (!text) return text;
-        return text.replace(/\b([A-Z]{2,}s?)\b/g, '<abbr>$1</abbr>');
+        // First escape HTML entities to prevent conflicts with angle brackets
+        const escaped = text.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+        return escaped.replace(/\b([A-Z]{2,}s?)\b/g, '<abbr>$1</abbr>');
     });
 
     eleventyConfig.addDataExtension("yml, yaml", (contents) => yaml.load(contents));


### PR DESCRIPTION
The abbr filter was causing post titles with angle brackets (like <blog>) to disappear when used with the safe filter. Now HTML entities are properly escaped before abbreviation processing to prevent conflicts.

🤖 Generated with [Claude Code](https://claude.ai/code)